### PR TITLE
Update subgraph for v2.1 events

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,19 @@
+name: Notify CPT
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: send telegram message on push
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            ${{ github.actor }} opened a PR for review:
+
+            ${{ github.event.pull_request.title }}  
+            ${{ github.event.pull_request._links.html.href }}      

--- a/abis/ZAuction.json
+++ b/abis/ZAuction.json
@@ -66,6 +66,67 @@
           "internalType": "address",
           "name": "bidder",
           "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "seller",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "nftAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "expireBlock",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "paymentToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "topLevelDomainId",
+          "type": "uint256"
+        }
+      ],
+      "name": "BidAcceptedV2",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "bidNonce",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "bidder",
+          "type": "address"
         }
       ],
       "name": "BidCancelled",
@@ -88,6 +149,31 @@
         }
       ],
       "name": "BuyNowPriceSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "paymentToken",
+          "type": "address"
+        }
+      ],
+      "name": "BuyNowPriceSetV2",
       "type": "event"
     },
     {
@@ -133,6 +219,55 @@
         {
           "indexed": true,
           "internalType": "address",
+          "name": "buyer",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "seller",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "nftAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "paymentToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "topLevelDomainId",
+          "type": "uint256"
+        }
+      ],
+      "name": "DomainSoldV2",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
           "name": "previousOwner",
           "type": "address"
         },
@@ -170,7 +305,7 @@
         },
         {
           "internalType": "uint256",
-          "name": "tokenId",
+          "name": "domainTokenId",
           "type": "uint256"
         },
         {
@@ -197,17 +332,88 @@
     {
       "inputs": [
         {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bidNonce",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "bidder",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "domainTokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minbid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startBlock",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expireBlock",
+          "type": "uint256"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "bidToken",
+          "type": "address"
+        }
+      ],
+      "name": "acceptBidV2",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
         },
         {
           "internalType": "uint256",
-          "name": "tokenId",
+          "name": "domainTokenId",
           "type": "uint256"
         }
       ],
       "name": "buyNow",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "domainTokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "buyNowV2",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -352,6 +558,119 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bidNonce",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minbid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startBlock",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expireBlock",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "bidToken",
+          "type": "address"
+        }
+      ],
+      "name": "createBidV2",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "data",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "defaultPaymentToken",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "domainTokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPaymentTokenForDomain",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getProxyAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "domainTokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getTopLevelId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "hub",
       "outputs": [
@@ -383,11 +702,17 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "legacyRegistrar",
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "networkPaymentToken",
       "outputs": [
         {
-          "internalType": "contract IRegistrar",
+          "internalType": "contract IERC20",
           "name": "",
           "type": "address"
         }
@@ -427,6 +752,11 @@
           "internalType": "address",
           "name": "holder",
           "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "paymentToken",
+          "type": "address"
         }
       ],
       "stateMutability": "view",
@@ -458,6 +788,19 @@
     },
     {
       "inputs": [],
+      "name": "registrar",
+      "outputs": [
+        {
+          "internalType": "contract IRegistrar",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "renounceOwnership",
       "outputs": [],
       "stateMutability": "nonpayable",
@@ -472,11 +815,42 @@
         },
         {
           "internalType": "uint256",
-          "name": "tokenId",
+          "name": "domainTokenId",
           "type": "uint256"
         }
       ],
       "name": "setBuyPrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "newDefaultToken",
+          "type": "address"
+        }
+      ],
+      "name": "setDefaultPaymentToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "domainNetworkId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "domainNetworkToken",
+          "type": "address"
+        }
+      ],
+      "name": "setNetworkToken",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -495,6 +869,19 @@
         }
       ],
       "name": "setTopLevelDomainFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "setWildToken",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -585,25 +972,6 @@
     {
       "inputs": [
         {
-          "internalType": "uint256",
-          "name": "id",
-          "type": "uint256"
-        }
-      ],
-      "name": "topLevelDomainIdOf",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
           "internalType": "address",
           "name": "newOwner",
           "type": "address"
@@ -612,6 +980,37 @@
       "name": "transferOwnership",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_defaultToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_wildToken",
+          "type": "address"
+        }
+      ],
+      "name": "upgradeFromV2",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "wildToken",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     }
   ],

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -3,5 +3,7 @@
   "zAuction_address": "0x411973Fa81158A4c7767a0D6F7dF62723fDd541F",
   "start_block": 14490643,
   "legacy_zAuction_address": "0x05cBD37cA528B7ea50800aA80ddD0F9F30C952F0",
-  "legacy_start_block": 13045518
+  "legacy_start_block": 13045518,
+  "wild_token": "0x2a3bFF78B79A009976EeA096a51A948a3dC00e34",
+  "wild_network_id": "0x196c0a1e30004b9998c97b363e44f1f4e97497e59d52ad151208e9393d70bb3b"
 }

--- a/config/rinkeby.json
+++ b/config/rinkeby.json
@@ -3,5 +3,7 @@
     "zAuction_address": "0xb2416Aed6f5439Ffa0eCCAaa2b643f3D9828f86B",
     "legacy_zAuction_address": "0x376030f58c76ECC288a4fce8F88273905544bC07",
     "start_block": 10334351,
-    "legacy_start_block": 10395137
+    "legacy_start_block": 10395137,
+    "wild_token": "0x3Ae5d499cfb8FB645708CC6DA599C90e64b33A79",
+    "wild_network_id": "0x196c0a1e30004b9998c97b363e44f1f4e97497e59d52ad151208e9393d70bb3b"
 } 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "prepare:goerli": "mustache config/goerli.json subgraph.template.yaml > subgraph.yaml",
     "prepare:kovan": "mustache config/kovan.json subgraph.template.yaml > subgraph.yaml",
-    "prepare:rinkeby": "mustache config/rinkeby.json subgraph.template.yaml > subgraph.yaml",
-    "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:rinkeby": "mustache config/rinkeby.json subgraph.template.yaml > subgraph.yaml && mustache config/rinkeby.json src/wildInfo.ts.template src/wildInfo.ts",
+    "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml && mustache config/mainnet.json src/wildInfo.ts.template src/wildInfo.ts",
     "deploy:goerli": "yarn prepare:goerli && yarn internal:deploy",
     "deploy:kovan": "yarn prepare:kovan && yarn internal:deploy",
     "deploy:rinkeby": "yarn prepare:rinkeby && yarn internal:deploy",

--- a/schema.graphql
+++ b/schema.graphql
@@ -6,6 +6,8 @@ type TokenSale @entity {
   buyer: Account!
   seller: Account!
   timestamp: BigInt!
+  paymentToken: String
+  topLevelDomainId: String
 }
 
 type DomainTokenSold @entity {
@@ -16,12 +18,15 @@ type DomainTokenSold @entity {
   tokenId: String!
   contractAddress: String!
   timestamp: BigInt!
+  paymentToken: String,
+  topLevelDomainId: String
 }
 
 type BuyPriceSet @entity {
   id: ID!
   tokenId: String!
   amount: BigInt!
+  paymentToken: String
 }
 
 type Cancellation @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -24,8 +24,7 @@ type DomainTokenSold @entity {
 }
 
 type BuyNowListing @entity {
-  # id: ID!
-  tokenId: String!
+  id: String! # tokenId
   amount: BigInt!
   paymentToken: String
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,8 +7,8 @@ type TokenSale @entity {
   buyer: Account!
   seller: Account!
   timestamp: BigInt!
-  paymentToken: String
-  topLevelDomainId: String
+  paymentToken: String!
+  topLevelDomainId: String!
 }
 
 type DomainTokenSold @entity {
@@ -19,12 +19,12 @@ type DomainTokenSold @entity {
   tokenId: String!
   contractAddress: String!
   timestamp: BigInt!
-  paymentToken: String,
-  topLevelDomainId: String
+  paymentToken: String!
+  topLevelDomainId: String!
 }
 
-type BuyPriceSet @entity {
-  id: ID!
+type BuyNowListing @entity {
+  # id: ID!
   tokenId: String!
   amount: BigInt!
   paymentToken: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,6 @@
 type TokenSale @entity {
   id: ID!
+  bidNonce: BigInt!
   tokenId: String!
   contractAddress: String!
   amount: BigInt!

--- a/src/wildInfo.ts
+++ b/src/wildInfo.ts
@@ -1,6 +1,6 @@
 import { Address } from "@graphprotocol/graph-ts";
 export function getWildTokenForNetwork(): Address {
-  return Address.fromString("0x3Ae5d499cfb8FB645708CC6DA599C90e64b33A79");
+  return Address.fromString("0x2a3bFF78B79A009976EeA096a51A948a3dC00e34");
 }
 
 export function getWildDomainNetworkIdForNetwork(): string {

--- a/src/wildInfo.ts
+++ b/src/wildInfo.ts
@@ -1,0 +1,8 @@
+import { Address } from "@graphprotocol/graph-ts";
+export function getWildTokenForNetwork(): Address {
+  return Address.fromString("0x3Ae5d499cfb8FB645708CC6DA599C90e64b33A79");
+}
+
+export function getWildDomainNetworkIdForNetwork(): string {
+  return "0x196c0a1e30004b9998c97b363e44f1f4e97497e59d52ad151208e9393d70bb3b";
+}

--- a/src/wildInfo.ts.template
+++ b/src/wildInfo.ts.template
@@ -1,0 +1,8 @@
+import { Address } from "@graphprotocol/graph-ts";
+export function getWildTokenForNetwork(): Address {
+  return Address.fromString("{{wild_token}}");
+}
+
+export function getWildDomainNetworkIdForNetwork(): string {
+  return "{{wild_network_id}}";
+}

--- a/src/zauction.ts
+++ b/src/zauction.ts
@@ -139,7 +139,7 @@ export function handleBuyNowPriceSet(event: BuyNowPriceSet): void {
   const listing = resolveListing(toPaddedHexString(event.params.tokenId));
 
   const contract = ZAuction.bind(event.address);
-
+  
   listing.amount = event.params.amount;
   listing.paymentToken = contract.wildToken().toHex();
   listing.save();

--- a/src/zauction.ts
+++ b/src/zauction.ts
@@ -10,7 +10,6 @@ import {
   DomainSold,
   BuyNowPriceSet,
   BidCancelled,
-  ZAuction,
 } from "../generated/ZAuction/ZAuction";
 import { toPaddedHexString } from "./utils";
 import { ethereum } from "@graphprotocol/graph-ts";
@@ -19,6 +18,10 @@ import {
   BuyNowPriceSetV2,
   DomainSoldV2,
 } from "../generated/LegacyZAuction/ZAuction";
+import { 
+  getWildTokenForNetwork,
+  getWildDomainNetworkIdForNetwork
+} from "./wildInfo";
 
 function resolveAccount(address: string): Account {
   let account = Account.load(address);
@@ -54,8 +57,7 @@ export function handleBidAccepted(event: BidAccepted): void {
     "-" +
     event.block.timestamp.toString();
 
-  const contract = ZAuction.bind(event.address);
-
+  // still check .bind with zauction here when local
   const sale = new TokenSale(saleId);
   sale.bidNonce = event.params.bidNonce;
   sale.tokenId = toPaddedHexString(event.params.tokenId);
@@ -64,8 +66,8 @@ export function handleBidAccepted(event: BidAccepted): void {
   sale.buyer = bidder.id;
   sale.seller = seller.id;
   sale.timestamp = event.block.timestamp;
-  sale.paymentToken = contract.wildToken().toHex();
-  sale.topLevelDomainId = contract.getTopLevelId(event.params.tokenId).toHex();
+  sale.paymentToken = getWildTokenForNetwork().toHex();
+  sale.topLevelDomainId = getWildDomainNetworkIdForNetwork()
 
   sale.save();
 }
@@ -111,6 +113,8 @@ export function handleDomainSold(event: DomainSold): void {
   domainSold.tokenId = toPaddedHexString(event.params.tokenId);
   domainSold.contractAddress = event.params.nftAddress.toHex();
   domainSold.timestamp = event.block.timestamp;
+  domainSold.paymentToken = getWildTokenForNetwork().toHex();
+  domainSold.topLevelDomainId = getWildDomainNetworkIdForNetwork()
 
   domainSold.save();
 }
@@ -138,10 +142,8 @@ export function handleDomainSoldV2(event: DomainSoldV2): void {
 export function handleBuyNowPriceSet(event: BuyNowPriceSet): void {
   const listing = resolveListing(toPaddedHexString(event.params.tokenId));
 
-  const contract = ZAuction.bind(event.address);
-  
   listing.amount = event.params.amount;
-  listing.paymentToken = contract.wildToken().toHex();
+  listing.paymentToken = getWildTokenForNetwork().toHex();
   listing.save();
 }
 

--- a/src/zauction.ts
+++ b/src/zauction.ts
@@ -11,8 +11,9 @@ import {
   BuyNowPriceSet,
   BidCancelled,
 } from "../generated/ZAuction/ZAuction";
-import { toPaddedHexString, uint256ToByteArray } from "./utils";
+import { toPaddedHexString } from "./utils";
 import { ethereum } from "@graphprotocol/graph-ts";
+import { BidAcceptedV2, BuyNowPriceSetV2, DomainSoldV2 } from "../generated/LegacyZAuction/ZAuction";
 
 function resolveAccount(address: string): Account {
   let account = Account.load(address);
@@ -47,6 +48,33 @@ export function handleBidAccepted(event: BidAccepted): void {
   sale.buyer = bidder.id;
   sale.seller = seller.id;
   sale.timestamp = event.block.timestamp;
+
+  sale.save();
+}
+
+export function handleBidAcceptedV2(event: BidAcceptedV2): void {
+  const bidder = resolveAccount(event.params.bidder.toHex());
+  bidder.save();
+  const seller = resolveAccount(event.params.seller.toHex());
+  seller.save();
+
+  const saleId =
+    event.params.nftAddress.toHexString() +
+    "-" +
+    event.params.tokenId.toString() +
+    "-" +
+    event.block.timestamp.toString();
+
+  const sale = new TokenSale(saleId);
+  sale.tokenId = toPaddedHexString(event.params.tokenId);
+  sale.contractAddress = event.params.nftAddress.toHex();
+  sale.amount = event.params.amount;
+  sale.buyer = bidder.id;
+  sale.seller = seller.id;
+  sale.timestamp = event.block.timestamp;
+  sale.paymentToken = event.params.paymentToken.toHex();
+  sale.topLevelDomainId = event.params.topLevelDomainId.toHex();
+
   sale.save();
 }
 
@@ -64,6 +92,27 @@ export function handleDomainSold(event: DomainSold): void {
   domainSold.tokenId = toPaddedHexString(event.params.tokenId);
   domainSold.contractAddress = event.params.nftAddress.toHex();
   domainSold.timestamp = event.block.timestamp;
+
+  domainSold.save();
+}
+
+export function handleDomainSoldV2(event: DomainSoldV2): void {
+  const domainSold = new DomainTokenSold(id(event));
+
+  const buyer = resolveAccount(event.params.buyer.toHex());
+  buyer.save();
+  const seller = resolveAccount(event.params.seller.toHex());
+  seller.save();
+
+  domainSold.buyer = buyer.id;
+  domainSold.seller = seller.id;
+  domainSold.amount = event.params.amount;
+  domainSold.tokenId = toPaddedHexString(event.params.tokenId);
+  domainSold.contractAddress = event.params.nftAddress.toHex();
+  domainSold.timestamp = event.block.timestamp;
+  domainSold.paymentToken = event.params.paymentToken.toHex();
+  domainSold.topLevelDomainId = event.params.topLevelDomainId.toHex();
+
   domainSold.save();
 }
 
@@ -72,6 +121,15 @@ export function handleBuyNowPriceSet(event: BuyNowPriceSet): void {
 
   priceSet.tokenId = toPaddedHexString(event.params.tokenId);
   priceSet.amount = event.params.amount;
+  priceSet.save();
+}
+
+export function handleBuyNowPriceSetV2(event: BuyNowPriceSetV2): void {
+  const priceSet = new BuyPriceSet(id(event));
+
+  priceSet.tokenId = toPaddedHexString(event.params.tokenId);
+  priceSet.amount = event.params.amount;
+  priceSet.paymentToken = event.params.paymentToken.toHex();
   priceSet.save();
 }
 

--- a/src/zauction.ts
+++ b/src/zauction.ts
@@ -42,6 +42,7 @@ export function handleBidAccepted(event: BidAccepted): void {
     event.block.timestamp.toString();
 
   const sale = new TokenSale(saleId);
+  sale.bidNonce = event.params.bidNonce;
   sale.tokenId = toPaddedHexString(event.params.tokenId);
   sale.contractAddress = event.params.nftAddress.toHex();
   sale.amount = event.params.amount;
@@ -66,6 +67,7 @@ export function handleBidAcceptedV2(event: BidAcceptedV2): void {
     event.block.timestamp.toString();
 
   const sale = new TokenSale(saleId);
+  sale.bidNonce = event.params.bidNonce;
   sale.tokenId = toPaddedHexString(event.params.tokenId);
   sale.contractAddress = event.params.nftAddress.toHex();
   sale.amount = event.params.amount;

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -23,10 +23,16 @@ dataSources:
       eventHandlers:
         - event: BidAccepted(uint256,indexed address,indexed address,uint256,address,uint256,uint256)
           handler: handleBidAccepted
+        - event: BidAcceptedV2(uint256,indexed address,indexed address,uint256,address,uint256,uint256,address,uint256)
+          handler: handleBidAcceptedV2
         - event: DomainSold(indexed address,indexed address,uint256,address,indexed uint256)
           handler: handleDomainSold
+        - event: DomainSoldV2(indexed address,indexed address,uint256,address,indexed uint256,address,uint256)
+          handler: handleDomainSoldV2
         - event: BuyNowPriceSet(indexed uint256,uint256)
           handler: handleBuyNowPriceSet
+        - event: BuyNowPriceSetV2(indexed uint256,uint256,address)
+          handler: handleBuyNowPriceSetV2
         - event: BidCancelled(uint256,indexed address)
           handler: handleBidCancelled
       file: ./src/zauction.ts


### PR DESCRIPTION
Spent time reading through the docs to see if I could find a way to write mappings with something similar to `function handleEvent(event: BidAccepted | BidAcceptedV2)` to  avoid the code replication in saving other properties but no luck so replicated the functions, if there is a better way let me know @Remscar 

Closes [AB#95](https://dev.azure.com/zero-wilderworld/07337eb7-a009-4103-8b97-ecb872053d7e/_workitems/edit/95)