### PR TITLE
Add indexId to subgraph entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,6 @@
 type TokenSale @entity {
   id: ID!
+  indexId: Int!
   bidNonce: BigInt!
   tokenId: String!
   contractAddress: String!
@@ -13,6 +14,7 @@ type TokenSale @entity {
 
 type DomainTokenSold @entity {
   id: ID!
+  indexId: Int!
   buyer: Account!
   seller: Account!
   amount: BigInt!
@@ -25,16 +27,23 @@ type DomainTokenSold @entity {
 
 type BuyNowListing @entity {
   id: String! # tokenId
+  indexId: Int!
   amount: BigInt!
   paymentToken: String
 }
 
 type Cancellation @entity {
   id: ID!
+  indexId: Int!
   bidNonce: BigInt!
   bidder: Account!
 }
 
 type Account @entity {
   id: ID!
+}
+
+type Global @entity {
+  id: ID!
+  uniqueEntityId: Int!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -12,6 +12,11 @@ type TokenSale @entity {
   topLevelDomainId: String!
 }
 
+type GlobalTokenSale @entity {
+  id: ID!
+  uniqueEntityId: Int!
+}
+
 type DomainTokenSold @entity {
   id: ID!
   indexId: Int!
@@ -25,11 +30,21 @@ type DomainTokenSold @entity {
   topLevelDomainId: String!
 }
 
+type GlobalDomainTokenSold @entity {
+  id: ID!
+  uniqueEntityId: Int!
+}
+
 type BuyNowListing @entity {
   id: String! # tokenId
   indexId: Int!
   amount: BigInt!
   paymentToken: String
+}
+
+type GlobalBuyNowListing @entity {
+  id: ID!
+  uniqueEntityId: Int!
 }
 
 type Cancellation @entity {
@@ -39,11 +54,11 @@ type Cancellation @entity {
   bidder: Account!
 }
 
-type Account @entity {
-  id: ID!
-}
-
-type Global @entity {
+type GlobalCancellation @entity {
   id: ID!
   uniqueEntityId: Int!
+}
+
+type Account @entity {
+  id: ID!
 }

--- a/src/wildInfo.ts
+++ b/src/wildInfo.ts
@@ -1,6 +1,6 @@
 import { Address } from "@graphprotocol/graph-ts";
 export function getWildTokenForNetwork(): Address {
-  return Address.fromString("0x2a3bFF78B79A009976EeA096a51A948a3dC00e34");
+  return Address.fromString("0x3Ae5d499cfb8FB645708CC6DA599C90e64b33A79");
 }
 
 export function getWildDomainNetworkIdForNetwork(): string {

--- a/src/zauction.ts
+++ b/src/zauction.ts
@@ -4,7 +4,10 @@ import {
   DomainTokenSold,
   BuyNowListing,
   Cancellation,
-  Global,
+  GlobalTokenSale,
+  GlobalDomainTokenSold,
+  GlobalBuyNowListing,
+  GlobalCancellation,
 } from "../generated/schema";
 import {
   BidAccepted,
@@ -21,10 +24,43 @@ import {
 } from "../generated/LegacyZAuction/ZAuction";
 import { getWildTokenForNetwork, getWildDomainNetworkIdForNetwork } from "./wildInfo";
 
-function getIndexId(): i32 {
-  let global = Global.load("1");
+function getIndexIdTokenSale(): i32 {
+  let global = GlobalTokenSale.load("1");
   if (!global) {
-    global = new Global("1");
+    global = new GlobalTokenSale("1");
+    global.uniqueEntityId = 0;
+  }
+  global.uniqueEntityId += 1;
+  global.save();
+  return global.uniqueEntityId;
+}
+
+function getIndexIdDomainTokenSold(): i32 {
+  let global = GlobalDomainTokenSold.load("1");
+  if (!global) {
+    global = new GlobalDomainTokenSold("1");
+    global.uniqueEntityId = 0;
+  }
+  global.uniqueEntityId += 1;
+  global.save();
+  return global.uniqueEntityId;
+}
+
+function getIndexIdBuyNowListing(): i32 {
+  let global = GlobalBuyNowListing.load("1");
+  if (!global) {
+    global = new GlobalBuyNowListing("1");
+    global.uniqueEntityId = 0;
+  }
+  global.uniqueEntityId += 1;
+  global.save();
+  return global.uniqueEntityId;
+}
+
+function getIndexIdCancellation(): i32 {
+  let global = GlobalCancellation.load("1");
+  if (!global) {
+    global = new GlobalCancellation("1");
     global.uniqueEntityId = 0;
   }
   global.uniqueEntityId += 1;
@@ -44,7 +80,7 @@ function resolveListing(tokenId: string): BuyNowListing {
   let listing = BuyNowListing.load(tokenId);
   if (!listing) {
     listing = new BuyNowListing(tokenId);
-    listing.indexId = getIndexId();
+    listing.indexId = getIndexIdBuyNowListing();
   }
   return listing as BuyNowListing;
 }
@@ -74,11 +110,11 @@ export function handleBidAccepted(event: BidAccepted): void {
   sale.contractAddress = event.params.nftAddress.toHex();
   sale.amount = event.params.amount;
   sale.buyer = bidder.id;
-  sale.seller = seller.id;  
+  sale.seller = seller.id;
   sale.timestamp = event.block.timestamp;
   sale.paymentToken = getWildTokenForNetwork().toHex();
   sale.topLevelDomainId = getWildDomainNetworkIdForNetwork();
-  sale.indexId = getIndexId();
+  sale.indexId = getIndexIdTokenSale();
 
   sale.save();
 }
@@ -106,7 +142,7 @@ export function handleBidAcceptedV2(event: BidAcceptedV2): void {
   sale.timestamp = event.block.timestamp;
   sale.paymentToken = event.params.paymentToken.toHex();
   sale.topLevelDomainId = event.params.topLevelDomainId.toHex();
-  sale.indexId = getIndexId();
+  sale.indexId = getIndexIdTokenSale();
 
   sale.save();
 }
@@ -127,7 +163,7 @@ export function handleDomainSold(event: DomainSold): void {
   domainSold.timestamp = event.block.timestamp;
   domainSold.paymentToken = getWildTokenForNetwork().toHex();
   domainSold.topLevelDomainId = getWildDomainNetworkIdForNetwork();
-  domainSold.indexId = getIndexId()
+  domainSold.indexId = getIndexIdDomainTokenSold();
 
   domainSold.save();
 }
@@ -148,7 +184,7 @@ export function handleDomainSoldV2(event: DomainSoldV2): void {
   domainSold.timestamp = event.block.timestamp;
   domainSold.paymentToken = event.params.paymentToken.toHex();
   domainSold.topLevelDomainId = event.params.topLevelDomainId.toHex();
-  domainSold.indexId = getIndexId();
+  domainSold.indexId = getIndexIdDomainTokenSold();
 
   domainSold.save();
 }
@@ -175,6 +211,6 @@ export function handleBidCancelled(event: BidCancelled): void {
   const bidder = resolveAccount(event.params.bidder.toHex());
   cancellation.bidNonce = event.params.bidNonce;
   cancellation.bidder = bidder.id;
-  cancellation.indexId = getIndexId();
+  cancellation.indexId = getIndexIdCancellation();
   cancellation.save();
 }


### PR DESCRIPTION
This allows querying when there are more than 6000 entities of one kind. 
Confirmed working locally with docker graph-node and deployed to zauction rinkeby, pending approval before deploying to zauction mainnet

Closes [AB#233](https://dev.azure.com/zero-wilderworld/07337eb7-a009-4103-8b97-ecb872053d7e/_workitems/edit/233)